### PR TITLE
Fix script tags in examples

### DIFF
--- a/examples/action-after-given-time-is-reached.md
+++ b/examples/action-after-given-time-is-reached.md
@@ -13,7 +13,7 @@ Embed player
 <p>Some Text</p>
 <!-- Player Container #1 -->
 <div id="player1" style="width:100%;height:360px;"></div>
-<script type="text/javscript">
+<script type="text/javascript">
    var js3qVideoPlayer;
     (function () {
         var _js3qi = setInterval(function () {

--- a/examples/action-after-video-completed.md
+++ b/examples/action-after-video-completed.md
@@ -13,7 +13,7 @@ Embed player
 <p>Some Text</p>
 <!-- Player Container #1 -->
 <div id="player1" style="width:100%;height:360px;"></div>
-<script type="text/javscript">
+<script type="text/javascript">
    var js3qVideoPlayer;
     (function () {
         var _js3qi = setInterval(function () {

--- a/examples/javascript-control-player.md
+++ b/examples/javascript-control-player.md
@@ -13,7 +13,7 @@ Embed player
 <p>Some Text</p>
 <!-- Player Container #1 -->
 <div id="player1" style="width:100%;height:360px;"></div>
-<script type="text/javscript">
+<script type="text/javascript">
    var js3qVideoPlayer;
     (function () {
         var _js3qi = setInterval(function () {

--- a/examples/receive-events.md
+++ b/examples/receive-events.md
@@ -13,7 +13,7 @@ Embed player
 <p>Some Text</p>
 <!-- Player Container #1 -->
 <div id="player1" style="width:100%;height:360px;"></div>
-<script type="text/javscript">
+<script type="text/javascript">
    var js3qVideoPlayer;
     (function () {
         var _js3qi = setInterval(function () {


### PR DESCRIPTION
This fixes a recurring typo in the `type` attribute of script tags in
the examples:

`text/javscript` -> `text/javascript`