### PR TITLE
Add missing configuration parameter `jscallback` to paywall example

### DIFF
--- a/examples/custom-paywall.md
+++ b/examples/custom-paywall.md
@@ -48,7 +48,8 @@ var js3qVideoPlayer;
                     'sticky': true,
                     'playlistbar' : true,
                     'layout' : 'responsive',
-                    'end' : 15
+                    'end' : 15,
+                    'jscallback': 'sdnPlayerBridge'
                 });
                 js3qVideoPlayer.init();
             }


### PR DESCRIPTION
The example will only work, if the global callback function `sdnPlayerBridge` is registered with the player.